### PR TITLE
feat: add LLM prompt template for experience bullet generation

### DIFF
--- a/resume/prompts/generate_resume_bullets.md
+++ b/resume/prompts/generate_resume_bullets.md
@@ -1,0 +1,62 @@
+You are a resume bullet generator. Your task is to generate up to **{{MAX_BULLET_COUNT}}** high-quality experience bullets for a **{{TARGET_ROLE}}** position based on provided project data and job requirements.
+
+---
+
+## Input Context
+
+**Target Role:** {{TARGET_ROLE}}
+
+**Job Requirements (sorted by relevance):**
+{{REQUIREMENTS}}
+
+**Experience Projects:**
+{{EXPERIENCE_PROJECTS}}
+
+---
+
+## Instructions
+
+Generate up to **{{MAX_BULLET_COUNT}}** resume bullets that:
+
+1. **Frame the work for a {{TARGET_ROLE}} audience.** Emphasize aspects of each project most relevant to this role. For example, if the target is a Data Engineer position, highlight data pipeline work, scale, and infrastructure; if it's a Software Engineer role, emphasize system design, code quality, and performance.
+
+2. **Draw only from the provided project data.** Do not invent domain knowledge, metrics, or details not present in the project context. If information is missing, infer conservatively or omit rather than fabricate.
+
+3. **Align with job requirements.** Prioritize bullets that satisfy multiple requirements from the list above. Insert relevant keywords naturally where they fit the narrative.
+
+4. **Use concrete, plain language.** Write as an engineer or analyst would naturally describe their work. Avoid corporate buzzwords like "spearheaded," "orchestrated," "leveraged," "optimized," "championed," "ideated," "transformed," "enhanced," "streamlined," or "utilized." Use simple verbs: built, automated, analyzed, created, improved, implemented, wrote, designed, reduced, increased.
+
+5. **Focus on what was done and what changed.** Skip abstract impact phrases like "improved efficiency" or "drove innovation" unless you can back them with specific numbers or scope.
+
+6. **Include metrics wherever possible.** Use numbers, percentages, timelines, or scale details to make outcomes believable and grounded.
+
+7. **Vary structure slightly.** Not every bullet should follow "Verb + Object + Result." Mix in different sentence patterns to sound more human.
+
+8. **Be concise yet impactful.** Each bullet should fit on 1-2 lines when formatted. Keep it tight but substantive.
+
+9. **Sound authentic and human-written.** Avoid AI tone or over-polished phrasing. Write like someone genuinely recounting their work.
+
+---
+
+## Output Format
+
+Return a JSON array of bullets with the following structure:
+```json
+[
+  {
+    "order": 1,
+    "text": "Built a real-time search API using Django and Postgres that reduced query latency by 80% and supported 10K requests per minute."
+  },
+  {
+    "order": 2,
+    "text": "Automated ETL pipeline for customer analytics using Python and Airflow, cutting manual processing time from 4 hours to 15 minutes."
+  }
+]
+```
+
+**Rules:**
+- `order`: Integer starting from 1, representing priority/impact ranking.
+- `text`: The bullet text itself.
+- Return **only valid JSON**. No extra commentary or explanations.
+- Generate at most **{{MAX_BULLET_COUNT}}** bullets.
+- Bullets with higher `order` values should correspond to lower priority/impact.


### PR DESCRIPTION
**Related Issue:** Closes #27

**Problem:**  
The system needs a reusable prompt template to guide the LLM in generating high-quality, role-specific experience bullets from structured project data and job requirements. The prompt must produce concise, authentic bullets that align with job requirements while avoiding AI-generated tone and corporate buzzwords.

**Changes:**  
- Created `resume/prompts/generate_experience_bullets.md` with placeholder variables for target role, max bullet count, requirements list, and experience projects data
- Designed prompt to emphasize role-specific framing, natural language, metrics inclusion, and requirement alignment
- Specified JSON output format with `order` and `text` fields for downstream validation and persistence
- Ensured compatibility with existing `fill_placeholders()` utility using simple `{{VARIABLE_NAME}}` syntax
- Included comprehensive instructions to prevent hallucination, enforce concrete language, and produce human-sounding bullets

**Testing:**  
The prompt template will be tested by:
1. Loading the markdown file and using `fill_placeholders()` with sample data (target role, requirements, experience projects)
2. Passing the filled prompt to `ClaudeClient.generate()`
3. Validating the returned JSON against the bullet schema
4. Reviewing generated bullets for tone, authenticity, requirement alignment, and metric inclusion
5. Verifying bullets avoid buzzwords and sound naturally written

**Value:**  
This prompt template enables consistent, high-quality bullet generation across all experience roles. By providing clear instructions on language style, requirement prioritization, and output format, it ensures generated bullets are both effective for ATS systems and authentic-sounding to human reviewers. The token-efficient design supports the simplified per-role generation approach while maintaining strong alignment with job requirements.