### PR TITLE
feat: add Pydantic schema for experience bullet validation

### DIFF
--- a/resume/schemas/experience_bullet_schema.py
+++ b/resume/schemas/experience_bullet_schema.py
@@ -1,0 +1,84 @@
+from typing import Annotated, List
+from pydantic import BaseModel, Field, field_validator
+
+
+class ExperienceBullet(BaseModel):
+    """Represents a single generated experience bullet for a resume.
+    
+    This schema validates individual bullet points returned by the LLM,
+    ensuring they contain meaningful text and proper ordering for display.
+    """
+    
+    order: Annotated[int, Field(ge=1, description="Priority ranking, starting from 1")]
+    text: Annotated[
+        str,
+        Field(
+            min_length=20,
+            max_length=500,
+            description="The bullet point text describing work accomplished"
+        )
+    ]
+    
+    @field_validator('text')
+    @classmethod
+    def validate_text_quality(cls, v: str) -> str:
+        """Ensure bullet text is non-empty after stripping whitespace.
+        
+        Args:
+            v: The bullet text to validate.
+            
+        Returns:
+            The validated and stripped bullet text.
+            
+        Raises:
+            ValueError: If the text is empty or contains only whitespace.
+        """
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Bullet text cannot be empty or whitespace-only")
+        return stripped
+
+
+class BulletListModel(BaseModel):
+    """Represents the complete response from the LLM containing multiple experience bullets.
+    
+    This schema validates that the LLM returns a properly structured list of bullets
+    and enforces constraints on the total number of bullets generated.
+    """
+    
+    bullets: List[ExperienceBullet] = Field(
+        description="List of generated experience bullets"
+    )
+    
+    @field_validator('bullets')
+    @classmethod
+    def validate_bullet_count(cls, v: List[ExperienceBullet]) -> List[ExperienceBullet]:
+        """Ensure at least one bullet is returned.
+        
+        Args:
+            v: The list of bullets to validate.
+            
+        Returns:
+            The validated list of bullets.
+            
+        Raises:
+            ValueError: If the list is empty.
+        """
+        if not v:
+            raise ValueError("Response must contain at least one bullet")
+        return v
+    
+    def validate_max_count(self, max_bullet_count: int) -> None:
+        """Validate that the number of bullets does not exceed the configured maximum.
+        
+        Args:
+            max_bullet_count: The maximum allowed number of bullets.
+            
+        Raises:
+            ValueError: If the bullet count exceeds the maximum.
+        """
+        if len(self.bullets) > max_bullet_count:
+            raise ValueError(
+                f"Response contains {len(self.bullets)} bullets, "
+                f"but maximum allowed is {max_bullet_count}"
+            )

--- a/resume/tests/schemas/test_experience_bullet_schema.py
+++ b/resume/tests/schemas/test_experience_bullet_schema.py
@@ -1,0 +1,180 @@
+# resume/tests/test_experience_bullet_schema.py
+from unittest import TestCase
+from pydantic import ValidationError
+from resume.schemas.experience_bullet_schema import ExperienceBullet, BulletListModel
+
+
+class ExperienceBulletTestCase(TestCase):
+    """Test suite for ExperienceBullet schema validation."""
+    
+    VALID_BULLET_TEXT = "Built a real-time search API using Django and Postgres that reduced query latency by 80%"
+    SHORT_TEXT = "Too short bullet"
+    LONG_TEXT = "x" * 501
+    WHITESPACE_TEXT = "   \n\t   "
+    EMPTY_TEXT = ""
+    
+    def test_valid_bullet(self):
+        """Test that valid bullet data passes validation."""
+        bullet = ExperienceBullet(order=1, text=self.VALID_BULLET_TEXT)
+        self.assertEqual(bullet.order, 1)
+        self.assertEqual(bullet.text, self.VALID_BULLET_TEXT)
+    
+    def test_text_stripped_on_validation(self):
+        """Test that whitespace is stripped from bullet text."""
+        bullet = ExperienceBullet(order=1, text=f"  {self.VALID_BULLET_TEXT}  \n")
+        self.assertEqual(bullet.text, self.VALID_BULLET_TEXT)
+    
+    def test_text_too_short(self):
+        """Test that text below minimum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=1, text=self.SHORT_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('text',) and 'at least 20 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_text_too_long(self):
+        """Test that text exceeding maximum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=1, text=self.LONG_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('text',) and 'at most 500 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_empty_text(self):
+        """Test that empty text raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=1, text=self.EMPTY_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('text',) for e in errors)
+        )
+    
+    def test_whitespace_only_text(self):
+        """Test that whitespace-only text raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=1, text=self.WHITESPACE_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('text',) for e in errors)
+        )
+    
+    def test_order_must_be_positive(self):
+        """Test that order must be at least 1."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=0, text=self.VALID_BULLET_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('order',) and 'greater than or equal to 1' in str(e['msg']) for e in errors)
+        )
+    
+    def test_order_negative(self):
+        """Test that negative order values raise validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=-1, text=self.VALID_BULLET_TEXT)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('order',) for e in errors)
+        )
+    
+    def test_missing_required_fields(self):
+        """Test that missing required fields raise validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            ExperienceBullet(order=1)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('text',) and e['type'] == 'missing' for e in errors)
+        )
+
+
+class BulletListModelTestCase(TestCase):
+    """Test suite for BulletListModel schema validation."""
+    
+    VALID_BULLET_TEXT_1 = "Built a real-time search API using Django and Postgres that reduced query latency by 80%"
+    VALID_BULLET_TEXT_2 = "Automated ETL pipeline for customer analytics using Python and Airflow"
+    
+    def test_valid_bullet_list(self):
+        """Test that valid bullet list passes validation."""
+        bullets_data = [
+            {"order": 1, "text": self.VALID_BULLET_TEXT_1},
+            {"order": 2, "text": self.VALID_BULLET_TEXT_2}
+        ]
+        model = BulletListModel(bullets=bullets_data)
+        self.assertEqual(len(model.bullets), 2)
+        self.assertEqual(model.bullets[0].order, 1)
+        self.assertEqual(model.bullets[1].text, self.VALID_BULLET_TEXT_2)
+    
+    def test_single_bullet_valid(self):
+        """Test that a single bullet is valid."""
+        bullets_data = [{"order": 1, "text": self.VALID_BULLET_TEXT_1}]
+        model = BulletListModel(bullets=bullets_data)
+        self.assertEqual(len(model.bullets), 1)
+    
+    def test_empty_bullet_list_fails(self):
+        """Test that empty bullet list raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            BulletListModel(bullets=[])
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any('at least one bullet' in str(e['msg']) for e in errors)
+        )
+    
+    def test_invalid_bullet_in_list(self):
+        """Test that invalid bullet in list raises validation error."""
+        bullets_data = [
+            {"order": 1, "text": self.VALID_BULLET_TEXT_1},
+            {"order": 2, "text": "short"}
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            BulletListModel(bullets=bullets_data)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'][0] == 'bullets' and e['loc'][1] == 1 for e in errors)
+        )
+    
+    def test_validate_max_count_within_limit(self):
+        """Test that validate_max_count passes when count is within limit."""
+        bullets_data = [
+            {"order": 1, "text": self.VALID_BULLET_TEXT_1},
+            {"order": 2, "text": self.VALID_BULLET_TEXT_2}
+        ]
+        model = BulletListModel(bullets=bullets_data)
+        try:
+            model.validate_max_count(max_bullet_count=3)
+        except ValueError:
+            self.fail("validate_max_count raised ValueError unexpectedly")
+    
+    def test_validate_max_count_at_limit(self):
+        """Test that validate_max_count passes when count equals limit."""
+        bullets_data = [
+            {"order": 1, "text": self.VALID_BULLET_TEXT_1},
+            {"order": 2, "text": self.VALID_BULLET_TEXT_2}
+        ]
+        model = BulletListModel(bullets=bullets_data)
+        try:
+            model.validate_max_count(max_bullet_count=2)
+        except ValueError:
+            self.fail("validate_max_count raised ValueError unexpectedly")
+    
+    def test_validate_max_count_exceeds_limit(self):
+        """Test that validate_max_count raises error when count exceeds limit."""
+        bullets_data = [
+            {"order": 1, "text": self.VALID_BULLET_TEXT_1},
+            {"order": 2, "text": self.VALID_BULLET_TEXT_2},
+            {"order": 3, "text": self.VALID_BULLET_TEXT_1}
+        ]
+        model = BulletListModel(bullets=bullets_data)
+        with self.assertRaises(ValueError) as cm:
+            model.validate_max_count(max_bullet_count=2)
+        self.assertIn("contains 3 bullets", str(cm.exception))
+        self.assertIn("maximum allowed is 2", str(cm.exception))
+    
+    def test_missing_bullets_field(self):
+        """Test that missing bullets field raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            BulletListModel()
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('bullets',) and e['type'] == 'missing' for e in errors)
+        )


### PR DESCRIPTION
**Related Issue:** Closes #28 

**Problem:**  
The system needs to validate LLM responses when generating experience bullets to ensure structured, type-safe data before persisting to the `ResumeExperienceBullet` model. Without validation, malformed LLM outputs could lead to data corruption or runtime errors during resume generation.

**Changes:**  
- Created `ExperienceBullet` Pydantic model to validate individual bullet structure (order, text with length constraints)
- Created `BulletListModel` to validate the complete LLM response containing multiple bullets
- Added field validators to enforce bullet text quality (non-empty after stripping, reasonable length between 20-500 characters)
- Implemented `validate_max_count()` method to ensure bullet count does not exceed configured maximum
- Added comprehensive unit tests covering valid inputs, edge cases, and various validation failure scenarios

**Testing:**  
Unit tests verify that the schemas correctly accept valid bullet data and reject invalid inputs including: text that's too short or too long, empty or whitespace-only text, invalid order values, empty bullet lists, and bullet counts exceeding the maximum. All tests pass, confirming the validation logic works as intended.

**Value:**  
This schema provides a critical validation layer between the LLM and the database, catching malformed outputs early with clear error messages. It ensures data integrity, prevents silent failures, and aligns with the system's design principle of validating all LLM outputs via Pydantic before persistence. This standardized validation approach will be consistently applied across all LLM-integrated modules.