### PR TITLE
feat: Add prompt for generating skill bullets

### DIFF
--- a/resume/prompts/generate_skill_bullets.md
+++ b/resume/prompts/generate_skill_bullets.md
@@ -1,0 +1,39 @@
+You are a resume skills generator. Extract and organize skills from requirements and experience bullets into categories.
+
+---
+
+## Input
+
+**Target Role:** {{TARGET_ROLE}}
+
+**Requirements:**
+{{REQUIREMENTS}}
+
+**Experience Bullets:**
+{{BULLETS}}
+
+---
+
+## Instructions
+
+Generate skill categories in JSON with this structure:
+```json
+[
+  {
+    "category": "<category name>",
+    "skills": "<comma-separated skills>"
+  }
+]
+```
+
+**Rules:**
+1. Only include skills mentioned in BOTH requirements and bullets
+2. Maximum 4 categories
+3. Focus on concrete technologies, programming languages, and tools only
+4. Exclude soft skills, methodologies, and descriptive phrases
+5. Only include categories directly relevant to the target role
+6. Skills must be tangible technical skills
+7. Return valid JSON only, no extra text
+
+**Examples of valid skills:** Python, Django, PostgreSQL, AWS, Docker-compose, React, Git
+**Examples of invalid skills:** problem-solving, Agile, leadership, best practices, communication


### PR DESCRIPTION
**Related Issue:** Closes #43 

**Problem:**  
The system requires a prompt template to generate skill categories for resumes based on job requirements and experience bullets. This prompt will be used by the ResumeWriter service to create structured skill sections that align with target roles.

**Changes:**  
- Created `resume/prompts/generate_skill_bullets.md` prompt template
- Defined three input placeholders: TARGET_ROLE, REQUIREMENTS, and BULLETS
- Specified JSON output format with category and skills fields
- Included constraints to limit output to 4 categories maximum
- Added rules to focus on concrete technical skills only and exclude soft skills
- Ensured skills must appear in both requirements and bullets to be included

**Testing:**  
The prompt template follows the same structure and placeholder convention as existing prompts (`generate_resume_bullets.md` and `parse_jd.md`). It can be validated by loading with `load_prompt()` and filling placeholders with `fill_placeholders()` from `resume/utils/llm_helpers.py`.

**Value:**  
Enables automated generation of targeted skill sections that match job requirements while maintaining consistency with experience bullets. The token-efficient design minimizes LLM costs while ensuring skills are relevant and properly categorized for the target role.