### PR TITLE
feat: add Pydantic schemas for LLM skill bullet validation

### DIFF
--- a/resume/schemas/skill_bullet_schema.py
+++ b/resume/schemas/skill_bullet_schema.py
@@ -1,0 +1,111 @@
+# resume/schemas/skill_bullet_schema.py
+from typing import Annotated, List
+from pydantic import BaseModel, Field, field_validator
+
+
+class SkillCategorySchema(BaseModel):
+    """Represents a single skill category with associated skills.
+    
+    This schema validates individual skill categories returned by the LLM,
+    ensuring they contain meaningful category names and valid skill lists.
+    """
+    
+    category: Annotated[
+        str,
+        Field(
+            min_length=3,
+            max_length=100,
+            description="The skill category name (e.g., 'Programming Languages')"
+        )
+    ]
+    skills: Annotated[
+        str,
+        Field(
+            min_length=2,
+            max_length=500,
+            description="Comma-separated list of technical skills"
+        )
+    ]
+    
+    @field_validator('category')
+    @classmethod
+    def validate_category_quality(cls, v: str) -> str:
+        """Ensure category name is non-empty after stripping whitespace.
+        
+        Args:
+            v: The category name to validate.
+            
+        Returns:
+            The validated and stripped category name.
+            
+        Raises:
+            ValueError: If the category is empty or contains only whitespace.
+        """
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Category name cannot be empty or whitespace-only")
+        return stripped
+    
+    @field_validator('skills')
+    @classmethod
+    def validate_skills_quality(cls, v: str) -> str:
+        """Ensure skills string is non-empty after stripping whitespace.
+        
+        Args:
+            v: The skills string to validate.
+            
+        Returns:
+            The validated and stripped skills string.
+            
+        Raises:
+            ValueError: If the skills string is empty or contains only whitespace.
+        """
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Skills string cannot be empty or whitespace-only")
+        return stripped
+
+
+class SkillBulletListModel(BaseModel):
+    """Represents the complete response from the LLM containing multiple skill categories.
+    
+    This schema validates that the LLM returns a properly structured list of skill
+    categories and enforces constraints on the total number of categories generated.
+    """
+    
+    skill_categories: List[SkillCategorySchema] = Field(
+        description="List of generated skill categories"
+    )
+    
+    @field_validator('skill_categories')
+    @classmethod
+    def validate_category_count(cls, v: List[SkillCategorySchema]) -> List[SkillCategorySchema]:
+        """Ensure at least one skill category is returned.
+        
+        Args:
+            v: The list of skill categories to validate.
+            
+        Returns:
+            The validated list of skill categories.
+            
+        Raises:
+            ValueError: If the list is empty.
+        """
+        if not v:
+            raise ValueError("Response must contain at least one skill category")
+        return v
+    
+    def validate_max_count(self, max_category_count: int) -> None:
+        """Validate that the number of categories does not exceed the configured maximum.
+        
+        Args:
+            max_category_count: The maximum allowed number of skill categories.
+            
+        Raises:
+            ValueError: If the category count exceeds the maximum.
+        """
+        if len(self.skill_categories) > max_category_count:
+            raise ValueError(
+                f"Response contains {len(self.skill_categories)} skill categories, "
+                f"but maximum allowed is {max_category_count}"
+            )

--- a/resume/tests/schemas/test_skill_bullet_schema.py
+++ b/resume/tests/schemas/test_skill_bullet_schema.py
@@ -1,0 +1,216 @@
+# resume/tests/test_skill_bullet_schema.py
+from unittest import TestCase
+from pydantic import ValidationError
+from resume.schemas.skill_bullet_schema import SkillCategorySchema, SkillBulletListModel
+
+
+class TestSkillCategorySchema(TestCase):
+    """Test suite for SkillCategorySchema validation."""
+    
+    VALID_CATEGORY = "Programming Languages"
+    VALID_SKILLS = "Python, Java, JavaScript, TypeScript"
+    SHORT_CATEGORY = "XY"
+    LONG_CATEGORY = "x" * 101
+    SHORT_SKILLS = "P"
+    LONG_SKILLS = "x" * 501
+    WHITESPACE_CATEGORY = "   \n\t   "
+    WHITESPACE_SKILLS = "   \n\t   "
+    EMPTY_CATEGORY = ""
+    EMPTY_SKILLS = ""
+    
+    def test_valid_skill_category(self):
+        """Test that valid skill category data passes validation."""
+        category = SkillCategorySchema(category=self.VALID_CATEGORY, skills=self.VALID_SKILLS)
+        self.assertEqual(category.category, self.VALID_CATEGORY)
+        self.assertEqual(category.skills, self.VALID_SKILLS)
+    
+    def test_category_stripped_on_validation(self):
+        """Test that whitespace is stripped from category name."""
+        category = SkillCategorySchema(
+            category=f"  {self.VALID_CATEGORY}  \n",
+            skills=self.VALID_SKILLS
+        )
+        self.assertEqual(category.category, self.VALID_CATEGORY)
+    
+    def test_skills_stripped_on_validation(self):
+        """Test that whitespace is stripped from skills string."""
+        category = SkillCategorySchema(
+            category=self.VALID_CATEGORY,
+            skills=f"  {self.VALID_SKILLS}  \n"
+        )
+        self.assertEqual(category.skills, self.VALID_SKILLS)
+    
+    def test_category_too_short(self):
+        """Test that category below minimum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.SHORT_CATEGORY, skills=self.VALID_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('category',) and 'at least 3 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_category_too_long(self):
+        """Test that category exceeding maximum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.LONG_CATEGORY, skills=self.VALID_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('category',) and 'at most 100 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_skills_too_short(self):
+        """Test that skills string below minimum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.VALID_CATEGORY, skills=self.SHORT_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skills',) and 'at least 2 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_skills_too_long(self):
+        """Test that skills string exceeding maximum length raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.VALID_CATEGORY, skills=self.LONG_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skills',) and 'at most 500 characters' in str(e['msg']) for e in errors)
+        )
+    
+    def test_empty_category(self):
+        """Test that empty category raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.EMPTY_CATEGORY, skills=self.VALID_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('category',) for e in errors)
+        )
+    
+    def test_empty_skills(self):
+        """Test that empty skills string raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.VALID_CATEGORY, skills=self.EMPTY_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skills',) for e in errors)
+        )
+    
+    def test_whitespace_only_category(self):
+        """Test that whitespace-only category raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.WHITESPACE_CATEGORY, skills=self.VALID_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('category',) for e in errors)
+        )
+    
+    def test_whitespace_only_skills(self):
+        """Test that whitespace-only skills string raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.VALID_CATEGORY, skills=self.WHITESPACE_SKILLS)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skills',) for e in errors)
+        )
+    
+    def test_missing_required_fields(self):
+        """Test that missing required fields raise validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillCategorySchema(category=self.VALID_CATEGORY)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skills',) and e['type'] == 'missing' for e in errors)
+        )
+
+
+class TestSkillBulletListModel(TestCase):
+    """Test suite for SkillBulletListModel schema validation."""
+    
+    VALID_CATEGORY_1 = "Programming Languages"
+    VALID_SKILLS_1 = "Python, Java, JavaScript"
+    VALID_CATEGORY_2 = "Data & Visualization"
+    VALID_SKILLS_2 = "PostgreSQL, Redis, D3.js"
+    
+    def test_valid_skill_category_list(self):
+        """Test that valid skill category list passes validation."""
+        categories_data = [
+            {"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1},
+            {"category": self.VALID_CATEGORY_2, "skills": self.VALID_SKILLS_2}
+        ]
+        model = SkillBulletListModel(skill_categories=categories_data)
+        self.assertEqual(len(model.skill_categories), 2)
+        self.assertEqual(model.skill_categories[0].category, self.VALID_CATEGORY_1)
+        self.assertEqual(model.skill_categories[1].skills, self.VALID_SKILLS_2)
+    
+    def test_single_category_valid(self):
+        """Test that a single skill category is valid."""
+        categories_data = [{"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1}]
+        model = SkillBulletListModel(skill_categories=categories_data)
+        self.assertEqual(len(model.skill_categories), 1)
+    
+    def test_empty_category_list_fails(self):
+        """Test that empty skill category list raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillBulletListModel(skill_categories=[])
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any('at least one skill category' in str(e['msg']) for e in errors)
+        )
+    
+    def test_invalid_category_in_list(self):
+        """Test that invalid skill category in list raises validation error."""
+        categories_data = [
+            {"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1},
+            {"category": self.VALID_CATEGORY_2, "skills": "x"}
+        ]
+        with self.assertRaises(ValidationError) as cm:
+            SkillBulletListModel(skill_categories=categories_data)
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'][0] == 'skill_categories' and e['loc'][1] == 1 for e in errors)
+        )
+    
+    def test_validate_max_count_within_limit(self):
+        """Test that validate_max_count passes when count is within limit."""
+        categories_data = [
+            {"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1},
+            {"category": self.VALID_CATEGORY_2, "skills": self.VALID_SKILLS_2}
+        ]
+        model = SkillBulletListModel(skill_categories=categories_data)
+        try:
+            model.validate_max_count(max_category_count=3)
+        except ValueError:
+            self.fail("validate_max_count raised ValueError unexpectedly")
+    
+    def test_validate_max_count_at_limit(self):
+        """Test that validate_max_count passes when count equals limit."""
+        categories_data = [
+            {"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1},
+            {"category": self.VALID_CATEGORY_2, "skills": self.VALID_SKILLS_2}
+        ]
+        model = SkillBulletListModel(skill_categories=categories_data)
+        try:
+            model.validate_max_count(max_category_count=2)
+        except ValueError:
+            self.fail("validate_max_count raised ValueError unexpectedly")
+    
+    def test_validate_max_count_exceeds_limit(self):
+        """Test that validate_max_count raises error when count exceeds limit."""
+        categories_data = [
+            {"category": self.VALID_CATEGORY_1, "skills": self.VALID_SKILLS_1},
+            {"category": self.VALID_CATEGORY_2, "skills": self.VALID_SKILLS_2},
+            {"category": "Cloud & DevOps", "skills": "AWS, Docker, Kubernetes"}
+        ]
+        model = SkillBulletListModel(skill_categories=categories_data)
+        with self.assertRaises(ValueError) as cm:
+            model.validate_max_count(max_category_count=2)
+        self.assertIn("contains 3 skill categories", str(cm.exception))
+        self.assertIn("maximum allowed is 2", str(cm.exception))
+    
+    def test_missing_skill_categories_field(self):
+        """Test that missing skill_categories field raises validation error."""
+        with self.assertRaises(ValidationError) as cm:
+            SkillBulletListModel()
+        errors = cm.exception.errors()
+        self.assertTrue(
+            any(e['loc'] == ('skill_categories',) and e['type'] == 'missing' for e in errors)
+        )


### PR DESCRIPTION
**Related Issue:** Closes #30 

**Problem:**  
The system needed validation schemas for skill bullet generation output from the LLM. Without these schemas, there was no type-safe mechanism to validate that skill categories and their associated skills conform to expected structure and constraints before persisting to the database.

**Changes:**  
- Created `SkillCategorySchema` to validate individual skill categories with constraints on category name length (3-100 chars) and skills string length (2-500 chars)
- Added field validators to strip whitespace and reject empty/whitespace-only values for both category names and skills strings
- Created `SkillBulletListModel` as the top-level schema that validates the complete LLM response containing a list of skill categories
- Implemented `validate_max_count()` method to enforce configurable maximum category limits (default max of 4 per design doc)
- Added comprehensive test coverage for both schemas including edge cases: empty values, whitespace-only strings, length boundaries, missing fields, and max count validation

**Testing:**  
The implementation includes full test suites (`TestSkillCategorySchema` and `TestSkillBulletListModel`) covering all validation paths. Tests verify proper handling of valid inputs, boundary conditions, whitespace stripping, empty/invalid values, and the `validate_max_count()` enforcement. Tests can be executed via `python manage.py test resume.tests.test_skill_bullet_schema`.

**Value:**  
These schemas ensure that all skill bullet data from the LLM is validated before database persistence, preventing malformed or incomplete skill categories from entering the system. This maintains data integrity and enables the `ResumeWriter.generate_skill_bullets()` method to safely validate LLM output using the existing `validate_with_schema()` helper, consistent with the validation approach used for experience bullets and JD parsing.